### PR TITLE
Maintain escaped characters on Batch read object

### DIFF
--- a/algoliasearch-cmd.sh
+++ b/algoliasearch-cmd.sh
@@ -333,7 +333,7 @@ case $1 in
             rm algolia_batch.json
         }
 
-        while read object; do
+        while read -r object; do
             BATCH+=("$object")
             if [ ${#BATCH[@]} -eq $BATCH_SIZE ]; then
                 push


### PR DESCRIPTION
Escaped characters in the JSON will not be escaped if the -r flag is not included.

The following JSON would previously addObjects to fail:

{
  "description": "The event was described as \"a spectacular experience\"."
}
